### PR TITLE
Update games list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ static NIGHTLY_RELEASE: &str = "REFramework-nightly";
 static REPO_OWNER: &str = "praydog";
 static GAMES: [(&str, &str); 6] = [
     ("2054970", "DD2"),
+    ("2187220", "DD2"),
+    ("2510710", "DD2"),
     ("601150", "DMC5"),
     ("1446780", "MHRISE"),
     ("2246340", "MHWILDS"),
@@ -84,6 +86,7 @@ static GAMES: [(&str, &str); 6] = [
     ("2050650", "RE4"),
     ("418370", "RE7"),
     ("1196590", "RE8"),
+    ("1375400", "RE8"),
     ("1364780", "SF6"),
 ];
 static GAMES_NEXTGEN_SUPPORT: [&str; 3] = ["RE2", "RE3", "RE7"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,12 +75,16 @@ pub type DynResult<T> = Result<T, Box<dyn Error>>;
 static NIGHTLY_RELEASE: &str = "REFramework-nightly";
 static REPO_OWNER: &str = "praydog";
 static GAMES: [(&str, &str); 6] = [
+    ("2054970", "DD2"),
     ("601150", "DMC5"),
     ("1446780", "MHRISE"),
+    ("2246340", "MHWILDS"),
     ("883710", "RE2"),
     ("952060", "RE3"),
+    ("2050650", "RE4"),
     ("418370", "RE7"),
     ("1196590", "RE8"),
+    ("1364780", "SF6"),
 ];
 static GAMES_NEXTGEN_SUPPORT: [&str; 3] = ["RE2", "RE3", "RE7"];
 


### PR DESCRIPTION
There are new supported games with reframework, a little refresh could be nice.

Here is the detailed list:
- Resident Evil 4
- Resident Evil Village
- Street Fighter 6
- Monster Hunter Wilds
- Dragon's Dogma 2
- Ghosts 'n Goblins Resurrection (Using RE8 build)
- Apollo Justice: Ace Attorney Trilogy (Using DD2 build)
- Kunitsu-Gami: Path of the Goddess (Using DD2 build)
